### PR TITLE
feat!: make all namedtuples typed, and remove unnormalized option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 [![Actions status](https://github.com/genomicmedlab/regbot/actions/workflows/checks.yaml/badge.svg)](https://github.com/genomicmedlab/regbot/actions/checks.yaml)
 
 <!-- description -->
-Fetch regulatory approval data for drug terms
+Acquire cleaned and structured data about drugs and therapeutics from US regulatory agencies and services:
+
+* ClinicalTrials.gov
+* Drugs@FDA
+* RxClass
 <!-- /description -->
 
-
+All data returned from regulatory APIs is structured as instances of standard library NamedTuples. This is done to give data structure and rudimentary type annotation (i.e. to benefit code editor and analysis tools) without adding runtime heft or being wedded to particular schema libraries like Pydantic. This may change in the future.
 
 ---
 

--- a/src/regbot/fetch/clinical_trials.py
+++ b/src/regbot/fetch/clinical_trials.py
@@ -44,6 +44,7 @@ import datetime
 import logging
 from collections import namedtuple
 from enum import StrEnum
+from typing import NamedTuple
 
 import requests
 from requests.exceptions import RequestException
@@ -550,9 +551,6 @@ def _format_outcomes(outcomes: dict) -> Outcomes:
     return Outcomes(primary_outcomes=primary, secondary_outcomes=secondary)
 
 
-Eligibility = namedtuple("Eligibility", ("min_age", "max_age", "std_age"))
-
-
 class StandardAge(StrEnum):
     """Define possible standardized age group values.
 
@@ -562,6 +560,17 @@ class StandardAge(StrEnum):
     CHILD = "child"
     ADULT = "adult"
     OLDER_ADULT = "older_adult"
+
+
+class Eligibility(NamedTuple):
+    """Describe eligibility for study
+
+    https://clinicaltrials.gov/data-api/about-api/study-data-structure#EligibilityModule
+    """
+
+    min_age: datetime.timedelta
+    max_age: datetime.timedelta
+    std_age: StandardAge
 
 
 # these are obviously imprecise, to varying degrees, but it's what we have to work with

--- a/src/regbot/fetch/clinical_trials.py
+++ b/src/regbot/fetch/clinical_trials.py
@@ -37,10 +37,6 @@ Get all serious adverse events:
     >>>          serious_events.append(event.term)
     >>> serious_events[:3]
     ['ANAEMIA', 'AUTOIMMUNE HAEMOLYTIC ANAEMIA', 'EVANS SYNDROME']
-
-The schema elements are structured as standard-library NamedTuple classes. This is done
-to provide very basic name-completion and type annotation, without being wedded to a
-particular schema library like Pydantic (though this could change in the future).
 """
 
 import datetime

--- a/tests/test_fetch_rxclass.py
+++ b/tests/test_fetch_rxclass.py
@@ -1,8 +1,18 @@
 from pathlib import Path
 
+import pytest
 import requests_mock
 
-from regbot.fetch.rxclass import get_drug_class_info
+from regbot.fetch.rxclass import (
+    ClassType,
+    DrugClassification,
+    DrugConcept,
+    Relation,
+    RelationSource,
+    RxClassEntry,
+    TermType,
+    get_drug_class_info,
+)
 
 
 def test_get_rxclass(fixtures_dir: Path):
@@ -22,4 +32,27 @@ def test_get_rxclass(fixtures_dir: Path):
             "https://rxnav.nlm.nih.gov/REST/rxclass/class/byDrugName.json?drugName=imatinib",
             text=json_response.read(),
         )
-        results = get_drug_class_info("imatinib", normalize=True)
+        results = get_drug_class_info("imatinib")
+        assert len(results) == 46
+        expected = RxClassEntry(
+            concept=DrugConcept(
+                concept_id="rxcui:282388",
+                name="imatinib",
+                term_type=TermType.IN,
+            ),
+            drug_classification=DrugClassification(
+                class_id="D054437",
+                class_name="Myelodysplastic-Myeloproliferative Diseases",
+                class_type=ClassType.DISEASE,
+                class_url=None,
+            ),
+            relation=Relation.MAY_TREAT,
+            relation_source=RelationSource.MEDRT,
+        )
+
+        for result in results:
+            if result == expected:
+                break
+        else:
+            msg = "No classification found relating imatinib to class ID D054437"
+            raise pytest.fail(msg)


### PR DESCRIPTION
* In an early version of regbot, I'd thought about trying to avoid collapsing all values into enums, but I think that's unnecessary so I'm removing the option
* Make all namedtuples type-annotated for editor integration